### PR TITLE
fix(redos-core): avoid ε-loop on NFA construction correctly

### DIFF
--- a/modules/redos-core/shared/src/test/scala/codes/quine/labo/redos/automaton/AutomatonCheckerSuite.scala
+++ b/modules/redos-core/shared/src/test/scala/codes/quine/labo/redos/automaton/AutomatonCheckerSuite.scala
@@ -30,6 +30,8 @@ class AutomatonCheckerSuite extends munit.FunSuite {
     assertEquals(check("(a*)*", ""), Success(Linear))
     assertEquals(check("^([a:]|\\b)*$", ""), Success(Linear))
     assertEquals(check("^(\\w|\\W)*$", "i"), Success(Linear))
+    assertEquals(check("^(a()*a)*$", ""), Success(Linear))
+    assertEquals(check("^(a(\\b)*:)*$", ""), Success(Linear))
   }
 
   test("AutomatonChecker.check: polynomial") {
@@ -41,7 +43,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
     )
     assertEquals(
       check("^(.a)*a(.a)*a$", "s"),
-      Success(Polynomial(2, Witness(Seq((Seq(other, a), Seq(a, a))), Seq(a, a, a))))
+      Success(Polynomial(2, Witness(Seq((Seq(a, a), Seq(a, a))), Seq(a, other, a, a, a))))
     )
     assertEquals(
       check("^.*a.*a.*a$", "s"),
@@ -68,7 +70,7 @@ class AutomatonCheckerSuite extends munit.FunSuite {
     )
     assertEquals(
       check("^(aa|b|aab)*$", ""),
-      Success(Exponential(Witness(Seq((Seq(a), Seq(a, a, a, b, a))), Seq(other2))))
+      Success(Exponential(Witness(Seq((Seq(a, a), Seq(b, a, a, b, a, a))), Seq(other2))))
     )
   }
 }

--- a/modules/redos-core/shared/src/test/scala/codes/quine/labo/redos/automaton/EpsNFACompilerSuite.scala
+++ b/modules/redos-core/shared/src/test/scala/codes/quine/labo/redos/automaton/EpsNFACompilerSuite.scala
@@ -23,13 +23,15 @@ class EpsNFACompilerSuite extends munit.FunSuite {
         Success(
           EpsNFA(
             ICharSet.any(false, false),
-            Set(0, 1, 2, 3),
+            Set(0, 1, 2, 3, 4, 5),
             2,
             1,
             Map(
               0 -> Assert(AssertKind.LineEnd, 1),
-              2 -> Eps(Seq(0, 3)),
-              3 -> Consume(Set(IChar.Any16), 2)
+              2 -> Eps(Seq(5, 3)),
+              3 -> LoopEnter(0, 4),
+              4 -> Consume(Set(IChar.Any16), 2),
+              5 -> LoopExit(0, 0)
             )
           )
         )
@@ -39,13 +41,15 @@ class EpsNFACompilerSuite extends munit.FunSuite {
         Success(
           EpsNFA(
             ICharSet.any(false, false),
-            Set(0, 1, 2, 3),
+            Set(0, 1, 2, 3, 4, 5),
             0,
-            2,
+            5,
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
-              1 -> Eps(Seq(2, 3)),
-              3 -> Consume(Set(IChar.Any16), 1)
+              1 -> Eps(Seq(4, 2)),
+              2 -> LoopEnter(0, 3),
+              3 -> Consume(Set(IChar.Any16), 1),
+              4 -> LoopExit(0, 5)
             )
           )
         )
@@ -294,17 +298,19 @@ class EpsNFACompilerSuite extends munit.FunSuite {
         Success(
           EpsNFA(
             ICharSet.any(false, false),
-            Set(0, 1, 2, 3, 4, 5, 6, 7),
+            Set(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
             0,
-            7,
+            9,
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(4)),
-              4 -> Eps(Seq(2, 5)),
+              4 -> Eps(Seq(5, 6)),
+              5 -> LoopEnter(0, 2),
               2 -> Consume(Set(IChar.Any16), 3),
               3 -> Eps(Seq(4)),
-              5 -> Eps(Seq(6)),
-              6 -> Assert(AssertKind.LineEnd, 7)
+              6 -> LoopExit(0, 7),
+              7 -> Eps(Seq(8)),
+              8 -> Assert(AssertKind.LineEnd, 9)
             )
           )
         )
@@ -314,17 +320,19 @@ class EpsNFACompilerSuite extends munit.FunSuite {
         Success(
           EpsNFA(
             ICharSet.any(false, false),
-            Set(0, 1, 2, 3, 4, 5, 6, 7),
+            Set(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
             0,
-            7,
+            9,
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(4)),
-              4 -> Eps(Seq(5, 2)),
+              4 -> Eps(Seq(6, 5)),
+              5 -> LoopEnter(0, 2),
               2 -> Consume(Set(IChar.Any16), 3),
               3 -> Eps(Seq(4)),
-              5 -> Eps(Seq(6)),
-              6 -> Assert(AssertKind.LineEnd, 7)
+              6 -> LoopExit(0, 7),
+              7 -> Eps(Seq(8)),
+              8 -> Assert(AssertKind.LineEnd, 9)
             )
           )
         )
@@ -337,16 +345,18 @@ class EpsNFACompilerSuite extends munit.FunSuite {
         Success(
           EpsNFA(
             ICharSet.any(false, false),
-            Set(0, 1, 2, 3, 4, 5, 6),
+            Set(0, 1, 2, 3, 4, 5, 6, 7, 8),
             0,
-            6,
+            8,
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(2)),
               2 -> Consume(Set(IChar.Any16), 3),
-              3 -> Eps(Seq(2, 4)),
-              4 -> Eps(Seq(5)),
-              5 -> Assert(AssertKind.LineEnd, 6)
+              3 -> Eps(Seq(4, 5)),
+              4 -> LoopEnter(0, 2),
+              5 -> LoopExit(0, 6),
+              6 -> Eps(Seq(7)),
+              7 -> Assert(AssertKind.LineEnd, 8)
             )
           )
         )
@@ -356,16 +366,18 @@ class EpsNFACompilerSuite extends munit.FunSuite {
         Success(
           EpsNFA(
             ICharSet.any(false, false),
-            Set(0, 1, 2, 3, 4, 5, 6),
+            Set(0, 1, 2, 3, 4, 5, 6, 7, 8),
             0,
-            6,
+            8,
             Map(
               0 -> Assert(AssertKind.LineBegin, 1),
               1 -> Eps(Seq(2)),
               2 -> Consume(Set(IChar.Any16), 3),
-              3 -> Eps(Seq(4, 2)),
-              4 -> Eps(Seq(5)),
-              5 -> Assert(AssertKind.LineEnd, 6)
+              3 -> Eps(Seq(5, 4)),
+              4 -> LoopEnter(0, 2),
+              5 -> LoopExit(0, 6),
+              6 -> Eps(Seq(7)),
+              7 -> Assert(AssertKind.LineEnd, 8)
             )
           )
         )

--- a/modules/redos-core/shared/src/test/scala/codes/quine/labo/redos/automaton/EpsNFASuite.scala
+++ b/modules/redos-core/shared/src/test/scala/codes/quine/labo/redos/automaton/EpsNFASuite.scala
@@ -1,12 +1,14 @@
 package codes.quine.labo.redos
 package automaton
 
+import scala.collection.immutable
+
 import EpsNFA._
 import data.IChar
 import data.ICharSet
 
 class EpsNFASuite extends munit.FunSuite {
-  test("EpsNFA.AssertKind.accepts") {
+  test("EpsNFA.AssertKind#accepts") {
     assert(AssertKind.LineBegin.accepts(CharInfo(true, false), CharInfo(false, false)))
     assert(!AssertKind.LineBegin.accepts(CharInfo(false, false), CharInfo(false, false)))
     assert(AssertKind.LineEnd.accepts(CharInfo(false, false), CharInfo(true, false)))
@@ -21,6 +23,24 @@ class EpsNFASuite extends munit.FunSuite {
     assert(!AssertKind.NotWordBoundary.accepts(CharInfo(false, false), CharInfo(false, true)))
   }
 
+  test("EpsNFA.AssertKind#toCharInfoSet") {
+    val neutral = CharInfo(false, false)
+    val lineTerminator = CharInfo(true, false)
+    val word = CharInfo(false, true)
+    assertEquals(AssertKind.LineBegin.toCharInfoSet(neutral), Set.empty[CharInfo])
+    assertEquals(AssertKind.LineBegin.toCharInfoSet(lineTerminator), Set(neutral, lineTerminator, word))
+    assertEquals(AssertKind.LineBegin.toCharInfoSet(word), Set.empty[CharInfo])
+    assertEquals(AssertKind.LineEnd.toCharInfoSet(neutral), Set(lineTerminator))
+    assertEquals(AssertKind.LineEnd.toCharInfoSet(lineTerminator), Set(lineTerminator))
+    assertEquals(AssertKind.LineEnd.toCharInfoSet(word), Set(lineTerminator))
+    assertEquals(AssertKind.WordBoundary.toCharInfoSet(neutral), Set(word))
+    assertEquals(AssertKind.WordBoundary.toCharInfoSet(lineTerminator), Set(word))
+    assertEquals(AssertKind.WordBoundary.toCharInfoSet(word), Set(neutral, lineTerminator))
+    assertEquals(AssertKind.NotWordBoundary.toCharInfoSet(neutral), Set(neutral, lineTerminator))
+    assertEquals(AssertKind.NotWordBoundary.toCharInfoSet(lineTerminator), Set(neutral, lineTerminator))
+    assertEquals(AssertKind.NotWordBoundary.toCharInfoSet(word), Set(word))
+  }
+
   test("EpsNFA.CharInfo.from") {
     assertEquals(CharInfo.from(IChar('a')), CharInfo(false, false))
     assertEquals(CharInfo.from(IChar('a').withLineTerminator), CharInfo(true, false))
@@ -30,14 +50,16 @@ class EpsNFASuite extends munit.FunSuite {
   test("EpsNFA#toGraphviz") {
     val nfa = EpsNFA(
       ICharSet.any(false, false).add(IChar('a')),
-      Set(0, 1, 2, 3, 4),
+      immutable.SortedSet(0, 1, 2, 3, 4, 5, 6),
       0,
-      4,
+      6,
       Map(
         0 -> Eps(Seq(1)),
         1 -> Eps(Seq(2, 3)),
         2 -> Consume(Set(IChar('a')), 4),
-        3 -> Assert(AssertKind.LineBegin, 4)
+        3 -> Assert(AssertKind.LineBegin, 4),
+        4 -> LoopEnter(0, 5),
+        5 -> LoopExit(0, 6)
       )
     )
     assertEquals(
@@ -54,7 +76,11 @@ class EpsNFASuite extends munit.FunSuite {
          |  "2" -> "4" [label="{[a]}"];
          |  "3" [shape=circle];
          |  "3" -> "4" [label="LineBegin"];
-         |  "4" [shape=doublecircle];
+         |  "4" [shape=circle];
+         |  "4" -> "5" [label="Enter(0)"];
+         |  "5" [shape=circle];
+         |  "5" -> "6" [label="Exit(0)"];
+         |  "6" [shape=doublecircle];
          |}""".stripMargin
     )
   }
@@ -62,61 +88,78 @@ class EpsNFASuite extends munit.FunSuite {
   test("EpsNFA#toOrderedNFA") {
     val nfa1 = EpsNFA(
       ICharSet.any(false, false).add(IChar('\n').withLineTerminator),
-      Set(0, 1, 2, 3, 4),
+      Set(0, 1, 2, 3, 4, 5, 6),
       0,
-      4,
+      6,
       Map(
-        0 -> Eps(Seq(1)),
-        1 -> Eps(Seq(0, 2, 3, 4)),
-        2 -> Consume(Set(IChar('\n').withLineTerminator), 1),
-        3 -> Assert(AssertKind.LineEnd, 1)
+        0 -> Eps(Seq(1, 5)),
+        1 -> LoopEnter(0, 2),
+        2 -> Eps(Seq(3, 4)),
+        3 -> Consume(Set(IChar('\n').withLineTerminator), 0),
+        4 -> Assert(AssertKind.LineEnd, 0),
+        5 -> LoopExit(0, 6)
       )
     )
     assertEquals(
       nfa1.toOrderedNFA(),
       OrderedNFA(
         Set(IChar('\n').withLineTerminator, IChar('\n').complement(false)),
-        Set((CharInfo(true, false), Seq(2, 3, 4)), (CharInfo(true, false), Seq(2, 3, 4, 2, 3, 4))),
-        Seq((CharInfo(true, false), Seq(2, 3, 4))),
-        Set((CharInfo(true, false), Seq(2, 3, 4)), (CharInfo(true, false), Seq(2, 3, 4, 2, 3, 4))),
+        Set((CharInfo(true, false), Seq(3, 6))),
+        Vector((CharInfo(true, false), Seq(3, 6))),
+        Set((CharInfo(true, false), Seq(3, 6))),
         Map(
-          ((CharInfo(true, false), Seq(2, 3, 4)), IChar('\n').withLineTerminator) -> Seq(
-            (CharInfo(true, false), Seq(2, 3, 4, 2, 3, 4)),
-            (CharInfo(true, false), Seq(2, 3, 4, 2, 3, 4))
-          ),
-          ((CharInfo(true, false), Seq(2, 3, 4)), IChar('\n').complement(false)) -> Seq.empty,
-          ((CharInfo(true, false), Seq(2, 3, 4, 2, 3, 4)), IChar('\n').withLineTerminator) -> Seq(
-            (CharInfo(true, false), Seq(2, 3, 4, 2, 3, 4)),
-            (CharInfo(true, false), Seq(2, 3, 4, 2, 3, 4)),
-            (CharInfo(true, false), Seq(2, 3, 4, 2, 3, 4)),
-            (CharInfo(true, false), Seq(2, 3, 4, 2, 3, 4)),
-            (CharInfo(true, false), Seq(2, 3, 4, 2, 3, 4))
-          ),
-          ((CharInfo(true, false), Seq(2, 3, 4, 2, 3, 4)), IChar('\n').complement(false)) -> Seq.empty
+          ((CharInfo(true, false), Seq(3, 6)), IChar('\n').withLineTerminator) -> Vector(
+            (CharInfo(true, false), Seq(3, 6))
+          )
         )
       )
     )
     val nfa2 = EpsNFA(
-      ICharSet.any(false, false).add(IChar('a')),
-      Set(0, 1),
+      ICharSet.any(false, false).add(IChar('\n').withLineTerminator).add(IChar('a').withWord),
+      Set(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
       0,
-      1,
+      10,
       Map(
-        0 -> Consume(Set(IChar('a')), 1)
+        0 -> Assert(AssertKind.LineEnd, 1),
+        1 -> Eps(Seq(2, 8)),
+        2 -> LoopEnter(0, 3),
+        3 -> Eps(Seq(4, 5)),
+        4 -> Consume(Set(IChar('\n').withLineTerminator), 1),
+        5 -> Consume(Set(IChar('a').withWord), 6),
+        6 -> Eps(Seq(7, 1)),
+        7 -> Assert(AssertKind.NotWordBoundary, 1),
+        8 -> LoopExit(0, 9),
+        9 -> Assert(AssertKind.WordBoundary, 10)
       )
     )
     assertEquals(
       nfa2.toOrderedNFA(),
       OrderedNFA(
-        Set(IChar('a'), IChar('a').complement(false)),
-        Set((CharInfo(true, false), Seq(0)), (CharInfo(false, false), Seq(1))),
-        Seq((CharInfo(true, false), Seq(0))),
-        Set((CharInfo(false, false), Seq(1))),
+        Set(IChar('\n').withLineTerminator, IChar('a').withWord, IChar('a').union(IChar('\n')).complement(false)),
+        Set(
+          (CharInfo(true, false), Seq(4)),
+          (CharInfo(true, false), Seq(4, 5)),
+          (CharInfo(false, true), Seq(5, 4, 5, 10))
+        ),
+        Vector((CharInfo(true, false), Seq(4))),
+        Set((CharInfo(false, true), Seq(5, 4, 5, 10))),
         Map(
-          ((CharInfo(true, false), Seq(0)), IChar('a')) -> Seq((CharInfo(false, false), Seq(1))),
-          ((CharInfo(true, false), Seq(0)), IChar('a').complement(false)) -> Seq.empty,
-          ((CharInfo(false, false), Seq(1)), IChar('a')) -> Seq.empty,
-          ((CharInfo(false, false), Seq(1)), IChar('a').complement(false)) -> Seq.empty
+          ((CharInfo(true, false), Seq(4)), IChar('\n').withLineTerminator) -> Vector(
+            (CharInfo(true, false), Seq(4, 5))
+          ),
+          ((CharInfo(true, false), Seq(4, 5)), IChar('a').withWord) -> Vector(
+            (CharInfo(false, true), Seq(5, 4, 5, 10))
+          ),
+          ((CharInfo(true, false), Seq(4, 5)), IChar('\n').withLineTerminator) -> Vector(
+            (CharInfo(true, false), Seq(4, 5))
+          ),
+          ((CharInfo(false, true), Seq(5, 4, 5, 10)), IChar('\n').withLineTerminator) -> Vector(
+            (CharInfo(true, false), Seq(4, 5))
+          ),
+          ((CharInfo(false, true), Seq(5, 4, 5, 10)), IChar('a').withWord) -> Vector(
+            (CharInfo(false, true), Seq(5, 4, 5, 10)),
+            (CharInfo(false, true), Seq(5, 4, 5, 10))
+          )
         )
       )
     )


### PR DESCRIPTION
This PR adds two kinds of ε-transitions named `LoopEnter` and `LoopExit` to detect ε-loop on NFA construction.

Now, `r*` is compiled to the following ε-NFA:

![loop](https://user-images.githubusercontent.com/6679325/103454963-26d00980-4d2c-11eb-9867-9c263f207a7d.png)
